### PR TITLE
feat: network client service token enhancement

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build and Test default scheme using any available iPhone simulator
     if: github.event.pull_request.draft == false
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: Add path globally
@@ -27,6 +27,7 @@ jobs:
 
       - name: Run Linter
         run: |
+          brew install swiftlint
           swiftlint --strict
 
       - name: Validate Pull Request Name
@@ -37,20 +38,22 @@ jobs:
 
       - name: Build and Test
         run: |
-          xcodebuild -scheme Networking-Package test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-            -enableCodeCoverage YES -resultBundlePath result.xcresult
-            
+          xcodebuild -scheme Networking-Package test \
+           -destination "platform=macOS,arch=arm64,variant=Mac Catalyst" \
+           -enableCodeCoverage YES \
+           -resultBundlePath result.xcresult
+
       - name: Run SonarCloud Scanning
         run: |
-          bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
-
+          bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
+          
           brew install sonar-scanner
 
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
-            -Dsonar.coverageReportPaths="Coverage.xml" \
+            -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
             -Dsonar.pullrequest.branch=${{github.head_ref}} \
             -Dsonar.pullrequest.base=${{github.base_ref}}

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Run Quality Report
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       contents: write
 
@@ -24,18 +24,20 @@ jobs:
 
       - name: Build and Test
         run: |
-          xcodebuild -scheme Networking-Package test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-            -enableCodeCoverage YES -resultBundlePath result.xcresult
+          xcodebuild -scheme Networking-Package test \
+           -destination "platform=macOS,arch=arm64,variant=Mac Catalyst" \
+           -enableCodeCoverage YES \
+           -resultBundlePath result.xcresult
             
       - name: Run SonarCloud Scanning
         run: |
-          bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
+          bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
 
           brew install sonar-scanner
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
-            -Dsonar.coverageReportPaths="Coverage.xml"
+            -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The iOS validation would need to be set-up in your app codebase Info.plist for d
 
 #### NetworkClient
 `NetworkClient` is a class with two public async throwing methods called `makeRequest` and `makeAuthorizedRequest` which handle network requests and return `Data`. 
+
 `NetworkClient` is initialised with a `URLSessionConfiguration`. It has a `convenience init` that initialises `configuration` with the `.ephemeral` singleton on `URLSessionConfiguration` which avoids needing to provide one at initialisation.
 
 For iOS 14 and later, certificates are pinned using `NSAppTransportSecurity`. Earlier versions of iOS use `SSLPinningDelegate` which conforms to `URLSessionDelegate` protocol to handle certificate pinning.

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ The iOS validation would need to be set-up in your app codebase Info.plist for d
 
 `Device` used to extend `Bundle` to provide an abstraction layer to decouple required properties for use in `UserAgent` struct and in mocks.
 
-`SecurityEvaluator` for handling evaulating server trust and getting certificates
+`SecurityEvaluator` for evaluating server trust and getting certificates
 
 
 ### Types
 
 #### NetworkClient
-`NetworkClient` is a class with one public async throwing method called `makeRequest` which handles network requests and returns `Data`. `NetworkClient` is initialised with a `URLSessionConfiguration`. It has a `convenience init` that initialises `configuration` with the `.ephemeral` singleton on `URLSessionConfiguration` which avoids needing to provide one at initialisation.
+`NetworkClient` is a class with two public async throwing methods called `makeRequest` and `makeAuthorizedRequest` which handle network requests and return `Data`. 
+`NetworkClient` is initialised with a `URLSessionConfiguration`. It has a `convenience init` that initialises `configuration` with the `.ephemeral` singleton on `URLSessionConfiguration` which avoids needing to provide one at initialisation.
 
 For iOS 14 and later, certificates are pinned using `NSAppTransportSecurity`. Earlier versions of iOS use `SSLPinningDelegate` which conforms to `URLSessionDelegate` protocol to handle certificate pinning.
 
@@ -65,8 +66,15 @@ The signature of the `makeRequest` method is:
 public func makeRequest(_ request: URLRequest) async throws -> Data
 ```
 
-`makeRequest` handles various response types and returns or throws errors as appropriate.
+The signature of the `makeAuthorizedRequest` method is:
 
+```swift
+public func makeAuthorizedRequest(exchangeRequest: URLRequest,
+                                  scope: String,
+                                  request: URLRequest) async throws -> Data
+```
+
+Both of these methods handle various response types and return or throw errors as appropriate.
 
 The `URLSessionConfiguration.tlsMinimumSupportedProtocolVersion` is then set to `.TLSv12` and `.httpAdditionalHeaders` is set like so:
 
@@ -75,12 +83,12 @@ configuration.httpAdditionalHeaders = ["User-Agent": UserAgent().description]
 ```
 
 #### SSLPinningDelegate
-`SSLPinningDelegate` class is used for handling certicate pinning in iOS 13 and earlier. In the ``NetworkClient`` initialiser it is called conditionally.
+`SSLPinningDelegate` class is used for handling certificate pinning in iOS 13 and earlier. In the ``NetworkClient`` initialiser it is called conditionally.
 
 Conforms to: `NSObject`, `URLSessionDelegate`
 
 #### X509CertificateSecurityEvaluator
-`X509CertificateSecurityEvaluator` concrete implmentation of `SecurityEvaulator`
+`X509CertificateSecurityEvaluator` concrete implementation of `SecurityEvaulator`
 
 Conforms to: `SecurityEvaluator`
 
@@ -114,7 +122,7 @@ Conforms to: `CustomStringConvertible`
 Conforms to: `CustomStringConvertible`
 
 #### Version 
-`Version` used as part of assembling the `UserAgent` properties. It has two initialisers. The one used when creating the `UserAgent` takes a `String` arguement and separates it into components for `major`, `minor` and `increment` version numbers which are then stored in constant properties. The other initialiser accepts separate `Int` types directly for `major`, `minor` and `increment`.
+`Version` used as part of assembling the `UserAgent` properties. It has two initialisers. The one used when creating the `UserAgent` takes a `String` argument and separates it into components for `major`, `minor` and `increment` version numbers which are then stored in constant properties. The other initialiser accepts separate `Int` types directly for `major`, `minor` and `increment`.
 
 Conforms to: `CustomStringConvertible`, `Decodable` and `Comparable`.
 
@@ -160,7 +168,7 @@ There is then an extension on `ServerError` which adds a `parameters` dictionary
 
 ### How to use the Network Client
 
-To use the `NetworkClient` first make sure your module or app has a dependency on `Networking` and the file has an import for `Networking`. Then initialise an instance of `NetworkClient` and create a URLRequest. Then make the network request using the `makeReqest` method. 
+To use the `NetworkClient` first make sure your module or app has a dependency on `Networking` and the file has an import for `Networking`. Then initialise an instance of `NetworkClient` and create a URLRequest. Then make the network request using the `makeRequest` method. 
 
 ```swift
 import Networking

--- a/Sources/MockNetworking/URLRequest+Extensions.swift
+++ b/Sources/MockNetworking/URLRequest+Extensions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension URLRequest {
-    public func bodySteamAsJSON() -> Any? {
+    public func httpBodyData() -> Data? {
         guard let bodyStream = self.httpBodyStream else { return nil }
         
         bodyStream.open()
@@ -18,16 +18,6 @@ extension URLRequest {
         
         buffer.deallocate()
         bodyStream.close()
-        
-        do {
-            return try JSONSerialization.jsonObject(with: data,
-                                                    options: JSONSerialization.ReadingOptions.allowFragments)
-            
-        } catch {
-            #if DEBUG
-            print(error.localizedDescription)
-            #endif
-            return nil
-        }
+        return data
     }
 }

--- a/Sources/Networking/Authentication/URLRequest+Extensions.swift
+++ b/Sources/Networking/Authentication/URLRequest+Extensions.swift
@@ -1,6 +1,22 @@
 import Foundation
 
 extension URLRequest {
+    static func tokenExchange(url: URL, subjectToken: String, scope: String) -> Self {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        var urlParser = URLComponents()
+        urlParser.queryItems = [
+            URLQueryItem(name: "grant-type", value: "urn:ietf:params:oauth:grant-type:token-exchange"),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "subject-token", value: subjectToken),
+            URLQueryItem(name: "subject-token-type", value: "urn:ietf:params:oauth:token-type:access_token")
+        ]
+        request.httpBody = urlParser.percentEncodedQuery?.data(using: .utf8)
+        
+        return request
+    }
+    
     func authorized(with token: String) -> Self {
         var request = self
         request.addValue("Bearer \(token)",

--- a/Sources/Networking/Authentication/URLRequest+Extensions.swift
+++ b/Sources/Networking/Authentication/URLRequest+Extensions.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 extension URLRequest {
-    static func tokenExchange(url: URL, subjectToken: String, scope: String) -> Self {
-        var request = URLRequest(url: url)
+    func tokenExchange(subjectToken: String, scope: String) -> Self {
+        var request = self
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         var urlParser = URLComponents()
@@ -13,7 +13,6 @@ extension URLRequest {
             URLQueryItem(name: "subject-token-type", value: "urn:ietf:params:oauth:token-type:access_token")
         ]
         request.httpBody = urlParser.percentEncodedQuery?.data(using: .utf8)
-        
         return request
     }
     

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -65,7 +65,7 @@ public final class NetworkClient {
         return try await makeRequest(authorizedRequest)
     }
     
-    func exchangeToken(exchangeRequest: URLRequest, scope: String) async throws -> ServiceTokenResponse {
+    private func exchangeToken(exchangeRequest: URLRequest, scope: String) async throws -> ServiceTokenResponse {
         guard let authenticationProvider else {
             assertionFailure("Authentication provider not present")
             throw NetworkClientError.authenticationProviderNotPresent
@@ -77,7 +77,7 @@ public final class NetworkClient {
         return try decodeServiceToken(data: serviceTokenResponse)
     }
     
-    func decodeServiceToken(data: Data) throws -> ServiceTokenResponse {
+    private func decodeServiceToken(data: Data) throws -> ServiceTokenResponse {
         let jsonDecoder = JSONDecoder()
         jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
         do {

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -49,13 +49,13 @@ public final class NetworkClient {
         }
     }
     
-    /// `makeAuthorizedRequest` method for making authenticated network requests has three parameters and returns `Data`
+    /// `makeAuthorizedRequest` method for making authorized network requests has three parameters and returns `Data`
     ///  the network client must be initialised with an authenticationProvider else an error is thrown
     ///
     /// - Parameters:
     ///   - exchangeRequest: ``URLRequest`` for the token exchange network request
-    ///   - scope: ``String`` for the scope of the authorized token
-    ///   - request: ``URLRequest`` for the authenticated network request
+    ///   - scope: ``String`` for the scope of the authenticated token
+    ///   - request: ``URLRequest`` for the authorized network request
     /// - Returns: ``Data`` the response data from the endpoint
     public func makeAuthorizedRequest(exchangeRequest: URLRequest,
                                       scope: String,

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -1,11 +1,6 @@
 import Combine
 import Foundation
 
-enum NetworkClientError: Error {
-    case authenticationProviderNotPresent
-    case unableToDecodeServiceTokenResponse
-}
-
 /// NetworkClient
 ///
 /// `NetworkClient` is a class with one public async throwing method called `makeRequest` which handles network requests and returns `Data`.

--- a/Sources/Networking/NetworkClientError.swift
+++ b/Sources/Networking/NetworkClientError.swift
@@ -1,0 +1,4 @@
+enum NetworkClientError: Error {
+    case authenticationProviderNotPresent
+    case unableToDecodeServiceTokenResponse
+}

--- a/Sources/Networking/ServiceTokenResponse.swift
+++ b/Sources/Networking/ServiceTokenResponse.swift
@@ -1,0 +1,5 @@
+struct ServiceTokenResponse: Decodable {
+    let accessToken: String
+    let tokenType: String
+    let expiresIn: Int
+}

--- a/Tests/NetworkingTests/Mocks/MockAuthenticationProvider.swift
+++ b/Tests/NetworkingTests/Mocks/MockAuthenticationProvider.swift
@@ -2,11 +2,5 @@ import Foundation
 @testable import Networking
 
 final class MockAuthenticationProvider: AuthenticationProvider {
-    // swiftlint:disable line_length
-  var bearerToken: String {
-      """
-zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
-"""
-    // swiftlint:enable line_length
-  }
+  var bearerToken: String = "testBearerToken"
 }

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -56,7 +56,7 @@ extension NetworkClientTests {
     func test_exchangeToken_returnsServerError() async throws {
         sut = .init(configuration: configuration, authenticationProvider: MockAuthenticationProvider())
         
-        let exchangeUrl = try XCTUnwrap(URL(string: "https://www.google.com"))
+        let exchangeUrl = try XCTUnwrap(URL(string: "https://www.test.com"))
         let data = try XCTUnwrap("{ }".data(using: . utf8))
         
         MockURLProtocol.handler = {
@@ -79,19 +79,18 @@ extension NetworkClientTests {
         let httpMethod = request.httpMethod
         XCTAssertEqual(contentType, "application/x-www-form-urlencoded")
         XCTAssertEqual(httpMethod, "POST")
-        //        let body = String(data: request.httpBody!, encoding: .utf8)?.split(separator: "&")
-        //
-        //        // swiftlint:disable line_length
-        //        let tokenToCheck = """
-        //      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
-        //      """
-        //        // swiftlint:enable line_length
-        //
-
-        //        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
-        //        XCTAssertEqual(body?[1], "scope=scope")
-        //        XCTAssertEqual(body?[2], "subject-token=\(tokenToCheck)")
-        //        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+//        let body = String(data: request.httpBody!, encoding: .utf8)?.split(separator: "&")
+//
+//        // swiftlint:disable line_length
+//        let tokenToCheck = """
+//      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
+//      """
+//        // swiftlint:enable line_length
+//
+//        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+//        XCTAssertEqual(body?[1], "scope=scope")
+//        XCTAssertEqual(body?[2], "subject-token=\(tokenToCheck)")
+//        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
     }
 
 //    func test_bearerToken_isInRequest() async throws {
@@ -146,7 +145,7 @@ extension NetworkClientTests {
         let jsonData = Data(data.utf8)
         
         do {
-            try sut.decodeServiceToken(data: jsonData)
+            _ = try sut.decodeServiceToken(data: jsonData)
         } catch {
             XCTAssert(error is NetworkClientError)
         }

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -6,16 +6,25 @@ final class NetworkClientTests: XCTestCase {
     private var configuration: URLSessionConfiguration!
     private var sut: NetworkClient!
     
+    private var exchangeUrlRequest: URLRequest!
+    private var urlRequest: URLRequest!
+    
     override func setUp() {
         super.setUp()
         
         configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
         
-        sut = .init(configuration: configuration)
+        exchangeUrlRequest = URLRequest(url: URL(string: "https://www.test.com")!)
+        urlRequest = URLRequest(url: URL(string: "https://www.test.com")!)
+        
+        sut = .init(configuration: configuration, authenticationProvider: MockAuthenticationProvider())
     }
     
     override func tearDown() {
+        exchangeUrlRequest = nil
+        urlRequest = nil
+        
         sut = nil
         super.tearDown()
     }
@@ -27,127 +36,115 @@ extension NetworkClientTests {
     }
     
     func test_makeRequest_returnsData() async throws {
-        let url = try XCTUnwrap(URL(string: "https://www.google.com"))
-        let data = try XCTUnwrap("{ }".data(using: . utf8))
+        let data = try XCTUnwrap("{ test }".data(using: . utf8))
         
         MockURLProtocol.handler = {
             (data, HTTPURLResponse(statusCode: 200))
         }
         
-        let returnedData = try await sut.makeRequest(URLRequest(url: url))
+        let returnedData = try await sut.makeRequest(urlRequest)
         XCTAssertEqual(returnedData, data)
     }
     
     func test_makeRequest_returnsServerError() async throws {
-        let url = try XCTUnwrap(URL(string: "https://www.google.com"))
-        let data = try XCTUnwrap("{ }".data(using: . utf8))
-        
         MockURLProtocol.handler = {
-            (data, HTTPURLResponse(statusCode: 404))
+            (Data(), HTTPURLResponse(statusCode: 404))
         }
         
         do {
-            _ = try await sut.makeRequest(URLRequest(url: url))
+            _ = try await sut.makeRequest(urlRequest)
         } catch {
             XCTAssert(error is ServerError)
         }
     }
     
-    func test_exchangeToken_returnsServerError() async throws {
-        sut = .init(configuration: configuration, authenticationProvider: MockAuthenticationProvider())
-        
-        let exchangeUrl = try XCTUnwrap(URL(string: "https://www.test.com"))
-        let data = try XCTUnwrap("{ }".data(using: . utf8))
-        
-        MockURLProtocol.handler = {
-            (data, HTTPURLResponse(statusCode: 404))
-        }
-        
-        do {
-            _ = try await sut.exchangeToken(exchangeRequest: URLRequest(url: exchangeUrl),
-                                                    scope: "scope")
-        } catch {
-            XCTAssert(error is ServerError)
-        }
-                
-        guard let request = MockURLProtocol.requests.first else {
-            XCTFail("request is nil")
-            return
-        }
-        
-        let contentType = request.value(forHTTPHeaderField: "Content-Type")
-        let httpMethod = request.httpMethod
-        XCTAssertEqual(contentType, "application/x-www-form-urlencoded")
-        XCTAssertEqual(httpMethod, "POST")
-//        let body = String(data: request.httpBody!, encoding: .utf8)?.split(separator: "&")
-//
-//        // swiftlint:disable line_length
-//        let tokenToCheck = """
-//      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
-//      """
-//        // swiftlint:enable line_length
-//
-//        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
-//        XCTAssertEqual(body?[1], "scope=scope")
-//        XCTAssertEqual(body?[2], "subject-token=\(tokenToCheck)")
-//        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
-    }
-
-//    func test_bearerToken_isInRequest() async throws {
-//        sut = .init(configuration: configuration, authenticationProvider: MockAuthenticationProvider())
-//        let url = try XCTUnwrap(URL(string: "https://www.google.com"))
-//        let data = try XCTUnwrap("{ }".data(using: . utf8))
-//        MockURLProtocol.handler = {
-//            (data, HTTPURLResponse(statusCode: 404))
-//        }
-//        do {
-//            _ = try await sut.makeRequest(URLRequest(url: url))
-//        } catch {
-//            XCTAssert(error is ServerError)
-//        }
-//        guard let request = MockURLProtocol.requests.first else {
-//            XCTFail("request is nil")
-//            return
-//        }
-//        let bearerToken = request.value(forHTTPHeaderField: "Authorization")
-//        // swiftlint:disable line_length
-//        let tokenToCheck = """
-//      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
-//      """
-//        // swiftlint:enable line_length
-//        XCTAssertEqual(bearerToken, tokenToCheck)
-//    }
-    
-    func test_decodeServiceToken_success() throws {
-        let data = """
+    func test_makeAuthorizedRequest_returnsData() async throws {
+        let exchangeData = try XCTUnwrap("""
             {
                 "access_token": "testAccessToken",
                 "token_type": "testTokenType",
                 "expires_in": 123456789
             }
-        """
-        let jsonData = Data(data.utf8)
-        let tokenResponse = try sut.decodeServiceToken(data: jsonData)
+        """.data(using: . utf8))
+        let data = try XCTUnwrap("{ test }".data(using: . utf8))
         
-        XCTAssertEqual(tokenResponse.accessToken, "testAccessToken")
-        XCTAssertEqual(tokenResponse.tokenType, "testTokenType")
-        XCTAssertEqual(tokenResponse.expiresIn, 123456789)
+        var requestsMade = 0
+        MockURLProtocol.handler = {
+            defer {
+                requestsMade += 1
+            }
+            switch requestsMade {
+            case 0:
+                return (exchangeData, HTTPURLResponse(statusCode: 200))
+            default:
+                return (data, HTTPURLResponse(statusCode: 200))
+            }
+        }
+        
+        let returnedData = try await sut.makeAuthorizedRequest(exchangeRequest: exchangeUrlRequest,
+                                                               scope: "testScope",
+                                                               request: urlRequest)
+        XCTAssertEqual(returnedData, data)
+        
+        let firstRequest = try XCTUnwrap(MockURLProtocol.requests.first)
+        let contentType = firstRequest.value(forHTTPHeaderField: "Content-Type")
+        let httpMethod = firstRequest.httpMethod
+        XCTAssertEqual(contentType, "application/x-www-form-urlencoded")
+        XCTAssertEqual(httpMethod, "POST")
+        let bodyData = try XCTUnwrap(firstRequest.httpBodyData())
+        let body = String(data: bodyData, encoding: .utf8)?.split(separator: "&")
+        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+        XCTAssertEqual(body?[1], "scope=testScope")
+        XCTAssertEqual(body?[2], "subject-token=testBearerToken")
+        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+        
+        let secondRequest = try XCTUnwrap(MockURLProtocol.requests.last)
+        let bearerToken = secondRequest.value(forHTTPHeaderField: "Authorization")
+        XCTAssertEqual(bearerToken, "Bearer testAccessToken")
     }
     
-    func test_decodeServiceToken_error() throws {
-        let data = """
+    func test_makeAuthorizedRequest_firstCall_returnsServerError() async throws {
+        MockURLProtocol.handler = {
+            (Data(), HTTPURLResponse(statusCode: 404))
+        }
+        
+        do {
+            _ = try await sut.makeAuthorizedRequest(exchangeRequest: exchangeUrlRequest,
+                                                    scope: "testScope",
+                                                    request: urlRequest)
+        } catch {
+            XCTAssert(error is ServerError)
+        }
+    }
+    
+    func test_makeAuthorizedRequest_secondCall_returnsServerError() async throws {
+        let exchangeData = try XCTUnwrap("""
             {
                 "access_token": "testAccessToken",
                 "token_type": "testTokenType",
-                "expires_in": "123456789"
+                "expires_in": 123456789
             }
-        """
-        let jsonData = Data(data.utf8)
+        """.data(using: . utf8))
+        
+        var requestsMade = 0
+        MockURLProtocol.handler = {
+            defer {
+                requestsMade += 1
+            }
+            switch requestsMade {
+            case 0:
+                return (exchangeData, HTTPURLResponse(statusCode: 200))
+            default:
+                return (Data(), HTTPURLResponse(statusCode: 404))
+            }
+        }
         
         do {
-            _ = try sut.decodeServiceToken(data: jsonData)
+            _ = try await sut.makeAuthorizedRequest(exchangeRequest: exchangeUrlRequest,
+                                                    scope: "testScope",
+                                                    request: urlRequest)
         } catch {
-            XCTAssert(error is NetworkClientError)
+            XCTAssert(error is ServerError)
         }
     }
 }

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -96,32 +96,26 @@ extension NetworkClientTests {
 
 //    func test_bearerToken_isInRequest() async throws {
 //        sut = .init(configuration: configuration, authenticationProvider: MockAuthenticationProvider())
-//        
 //        let url = try XCTUnwrap(URL(string: "https://www.google.com"))
 //        let data = try XCTUnwrap("{ }".data(using: . utf8))
-//        
 //        MockURLProtocol.handler = {
 //            (data, HTTPURLResponse(statusCode: 404))
 //        }
-//        
 //        do {
 //            _ = try await sut.makeRequest(URLRequest(url: url))
 //        } catch {
 //            XCTAssert(error is ServerError)
 //        }
-//        
 //        guard let request = MockURLProtocol.requests.first else {
 //            XCTFail("request is nil")
 //            return
 //        }
-//        
 //        let bearerToken = request.value(forHTTPHeaderField: "Authorization")
 //        // swiftlint:disable line_length
 //        let tokenToCheck = """
 //      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
 //      """
 //        // swiftlint:enable line_length
-//        
 //        XCTAssertEqual(bearerToken, tokenToCheck)
 //    }
     
@@ -150,6 +144,7 @@ extension NetworkClientTests {
             }
         """
         let jsonData = Data(data.utf8)
+        
         do {
             try sut.decodeServiceToken(data: jsonData)
         } catch {

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -36,7 +36,7 @@ extension NetworkClientTests {
     }
     
     func test_makeRequest_returnsData() async throws {
-        let data = try XCTUnwrap("{ test }".data(using: . utf8))
+        let data = try XCTUnwrap("{ test }".data(using: .utf8))
         
         MockURLProtocol.handler = {
             (data, HTTPURLResponse(statusCode: 200))
@@ -65,8 +65,8 @@ extension NetworkClientTests {
                 "token_type": "testTokenType",
                 "expires_in": 123456789
             }
-        """.data(using: . utf8))
-        let data = try XCTUnwrap("{ test }".data(using: . utf8))
+        """.data(using: .utf8))
+        let data = try XCTUnwrap("{ test }".data(using: .utf8))
         
         var requestsMade = 0
         MockURLProtocol.handler = {
@@ -124,7 +124,7 @@ extension NetworkClientTests {
                 "token_type": "testTokenType",
                 "expires_in": 123456789
             }
-        """.data(using: . utf8))
+        """.data(using: .utf8))
         
         var requestsMade = 0
         MockURLProtocol.handler = {

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -53,11 +53,10 @@ extension NetworkClientTests {
         }
     }
     
-    func test_bearerToken_isInRequest() async throws {
-        sut = nil
+    func test_exchangeToken_returnsServerError() async throws {
         sut = .init(configuration: configuration, authenticationProvider: MockAuthenticationProvider())
         
-        let url = try XCTUnwrap(URL(string: "https://www.google.com"))
+        let exchangeUrl = try XCTUnwrap(URL(string: "https://www.google.com"))
         let data = try XCTUnwrap("{ }".data(using: . utf8))
         
         MockURLProtocol.handler = {
@@ -65,23 +64,96 @@ extension NetworkClientTests {
         }
         
         do {
-            _ = try await sut.makeRequest(URLRequest(url: url))
+            _ = try await sut.exchangeToken(exchangeRequest: URLRequest(url: exchangeUrl),
+                                                    scope: "scope")
         } catch {
             XCTAssert(error is ServerError)
         }
-        
+                
         guard let request = MockURLProtocol.requests.first else {
             XCTFail("request is nil")
             return
         }
         
-        let bearerToken = request.value(forHTTPHeaderField: "Authorization")
-        // swiftlint:disable line_length
-        let tokenToCheck = """
-      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
-      """
-        // swiftlint:enable line_length
+        let contentType = request.value(forHTTPHeaderField: "Content-Type")
+        let httpMethod = request.httpMethod
+        XCTAssertEqual(contentType, "application/x-www-form-urlencoded")
+        XCTAssertEqual(httpMethod, "POST")
+        //        let body = String(data: request.httpBody!, encoding: .utf8)?.split(separator: "&")
+        //
+        //        // swiftlint:disable line_length
+        //        let tokenToCheck = """
+        //      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
+        //      """
+        //        // swiftlint:enable line_length
+        //
+
+        //        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+        //        XCTAssertEqual(body?[1], "scope=scope")
+        //        XCTAssertEqual(body?[2], "subject-token=\(tokenToCheck)")
+        //        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+    }
+
+//    func test_bearerToken_isInRequest() async throws {
+//        sut = .init(configuration: configuration, authenticationProvider: MockAuthenticationProvider())
+//        
+//        let url = try XCTUnwrap(URL(string: "https://www.google.com"))
+//        let data = try XCTUnwrap("{ }".data(using: . utf8))
+//        
+//        MockURLProtocol.handler = {
+//            (data, HTTPURLResponse(statusCode: 404))
+//        }
+//        
+//        do {
+//            _ = try await sut.makeRequest(URLRequest(url: url))
+//        } catch {
+//            XCTAssert(error is ServerError)
+//        }
+//        
+//        guard let request = MockURLProtocol.requests.first else {
+//            XCTFail("request is nil")
+//            return
+//        }
+//        
+//        let bearerToken = request.value(forHTTPHeaderField: "Authorization")
+//        // swiftlint:disable line_length
+//        let tokenToCheck = """
+//      Bearer zh2JZEiVWK9AHJNQN3TiK7MFjbuECjyA-I9uL9oFHmNZv0v4HnJrs64ZiNjp9nOSJjAM7gBIWJXlnzxG07/wzSE?neXnLinU6YYAZ!Q2CRwxkeqWT=hBapLWnbP1g/5j2MXlnY7gw2T=?i6nBI86=MJ1NR!fxqlwg4iI73x9HTL15i6urRrICHEps2BEy0c0uAet6USg6dpy0fFnf6Cf!ZozO37TOJB=T7!FooE8HDlM8WXggsO6cDQdDzRS43gL
+//      """
+//        // swiftlint:enable line_length
+//        
+//        XCTAssertEqual(bearerToken, tokenToCheck)
+//    }
+    
+    func test_decodeServiceToken_success() throws {
+        let data = """
+            {
+                "access_token": "testAccessToken",
+                "token_type": "testTokenType",
+                "expires_in": 123456789
+            }
+        """
+        let jsonData = Data(data.utf8)
+        let tokenResponse = try sut.decodeServiceToken(data: jsonData)
         
-        XCTAssertEqual(bearerToken, tokenToCheck)
+        XCTAssertEqual(tokenResponse.accessToken, "testAccessToken")
+        XCTAssertEqual(tokenResponse.tokenType, "testTokenType")
+        XCTAssertEqual(tokenResponse.expiresIn, 123456789)
+    }    
+    
+    func test_decodeServiceToken_error() throws {
+        let data = """
+            {
+                "access_token": "testAccessToken",
+                "token_type": "testTokenType",
+                "expires_in": "123456789"
+            }
+        """
+        let jsonData = Data(data.utf8)
+        do {
+            try sut.decodeServiceToken(data: jsonData)
+        } catch {
+            XCTAssert(error is NetworkClientError)
+        }
     }
 }

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -36,7 +36,7 @@ extension NetworkClientTests {
     }
     
     func test_makeRequest_returnsData() async throws {
-        let data = try XCTUnwrap("{ test }".data(using: .utf8))
+        let data = try XCTUnwrap("{ testResult }".data(using: .utf8))
         
         MockURLProtocol.handler = {
             (data, HTTPURLResponse(statusCode: 200))
@@ -66,7 +66,7 @@ extension NetworkClientTests {
                 "expires_in": 123456789
             }
         """.data(using: .utf8))
-        let data = try XCTUnwrap("{ test }".data(using: .utf8))
+        let data = try XCTUnwrap("{ testResult }".data(using: .utf8))
         
         var requestsMade = 0
         MockURLProtocol.handler = {
@@ -92,11 +92,11 @@ extension NetworkClientTests {
         XCTAssertEqual(contentType, "application/x-www-form-urlencoded")
         XCTAssertEqual(httpMethod, "POST")
         let bodyData = try XCTUnwrap(firstRequest.httpBodyData())
-        let body = String(data: bodyData, encoding: .utf8)?.split(separator: "&")
-        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
-        XCTAssertEqual(body?[1], "scope=testScope")
-        XCTAssertEqual(body?[2], "subject-token=testBearerToken")
-        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+        let body = try XCTUnwrap(String(data: bodyData, encoding: .utf8)?.split(separator: "&"))
+        XCTAssertEqual(body[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+        XCTAssertEqual(body[1], "scope=testScope")
+        XCTAssertEqual(body[2], "subject-token=testBearerToken")
+        XCTAssertEqual(body[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
         
         let secondRequest = try XCTUnwrap(MockURLProtocol.requests.last)
         let bearerToken = secondRequest.value(forHTTPHeaderField: "Authorization")

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -133,7 +133,7 @@ extension NetworkClientTests {
         XCTAssertEqual(tokenResponse.accessToken, "testAccessToken")
         XCTAssertEqual(tokenResponse.tokenType, "testTokenType")
         XCTAssertEqual(tokenResponse.expiresIn, 123456789)
-    }    
+    }
     
     func test_decodeServiceToken_error() throws {
         let data = """

--- a/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
+++ b/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
@@ -1,0 +1,38 @@
+@testable import Networking
+import XCTest
+
+final class URLRequestTests: XCTestCase {
+    var sut: URLRequest!
+    
+    override func setUp() {
+        super.setUp()
+        sut = URLRequest(url: URL(string: "https://www.google.com")!)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+}
+
+extension URLRequestTests {
+    func test_tokenExchange() throws {
+        let tokenRequest = sut.tokenExchange(subjectToken: "tesSubjectToken", scope: "testScope")
+        let contentTypeHeaer = tokenRequest.value(forHTTPHeaderField: "Content-Type")
+        let httpMethod = tokenRequest.httpMethod
+        let body = String(data: tokenRequest.httpBody!, encoding: .utf8)?.split(separator: "&")
+        XCTAssertEqual(tokenRequest.url, URL(string: "https://www.google.com"))
+        XCTAssertEqual(contentTypeHeaer, "application/x-www-form-urlencoded")
+        XCTAssertEqual(httpMethod, "POST")
+        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+        XCTAssertEqual(body?[1], "scope=testScope")
+        XCTAssertEqual(body?[2], "subject-token=tesSubjectToken")
+        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+    }
+    
+    func test_authorized() throws {
+        let authorizedRequest = sut.authorized(with: "testBearerToken")
+        let authorizationHeader = authorizedRequest.value(forHTTPHeaderField: "Authorization")
+        XCTAssertEqual(authorizationHeader, "Bearer testBearerToken")
+    }
+}

--- a/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
+++ b/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
@@ -18,16 +18,16 @@ final class URLRequestTests: XCTestCase {
 extension URLRequestTests {
     func test_tokenExchange() throws {
         let tokenRequest = sut.tokenExchange(subjectToken: "tesSubjectToken", scope: "testScope")
-        let contentTypeHeaer = tokenRequest.value(forHTTPHeaderField: "Content-Type")
+        let contentTypeHeader = tokenRequest.value(forHTTPHeaderField: "Content-Type")
         let httpMethod = tokenRequest.httpMethod
-        let body = String(data: tokenRequest.httpBody!, encoding: .utf8)?.split(separator: "&")
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(tokenRequest.httpBody), encoding: .utf8)?.split(separator: "&"))
         XCTAssertEqual(tokenRequest.url, URL(string: "https://www.google.com"))
-        XCTAssertEqual(contentTypeHeaer, "application/x-www-form-urlencoded")
+        XCTAssertEqual(contentTypeHeader, "application/x-www-form-urlencoded")
         XCTAssertEqual(httpMethod, "POST")
-        XCTAssertEqual(body?[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
-        XCTAssertEqual(body?[1], "scope=testScope")
-        XCTAssertEqual(body?[2], "subject-token=tesSubjectToken")
-        XCTAssertEqual(body?[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+        XCTAssertEqual(body[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+        XCTAssertEqual(body[1], "scope=testScope")
+        XCTAssertEqual(body[2], "subject-token=tesSubjectToken")
+        XCTAssertEqual(body[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
     }
     
     func test_authorized() throws {


### PR DESCRIPTION
# DCMAW-8621: iOS | Authenticated Requests | Initialise NetworkClient with Authentication Provider

Implementing authenticated requests with service token exchange through a new authorized request API:
```swift
public func makeAuthorizedRequest(exchangeRequest: URLRequest,
                                  scope: String,
                                  request: URLRequest) async throws -> Data
```

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
