### PR TITLE
fix: token request replace hyphens with underscores

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin@v4
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -18,9 +18,10 @@ jobs:
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin@v4
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # pin@v4
         with:
           lfs: 'true'
+          fetch-depth: 0
 
       - name: Xcode select
         run: |

--- a/Sources/Networking/Authentication/URLRequest+Extensions.swift
+++ b/Sources/Networking/Authentication/URLRequest+Extensions.swift
@@ -7,10 +7,10 @@ extension URLRequest {
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         var urlParser = URLComponents()
         urlParser.queryItems = [
-            URLQueryItem(name: "grant-type", value: "urn:ietf:params:oauth:grant-type:token-exchange"),
+            URLQueryItem(name: "grant_type", value: "urn:ietf:params:oauth:grant-type:token-exchange"),
             URLQueryItem(name: "scope", value: scope),
-            URLQueryItem(name: "subject-token", value: subjectToken),
-            URLQueryItem(name: "subject-token-type", value: "urn:ietf:params:oauth:token-type:access_token")
+            URLQueryItem(name: "subject_token", value: subjectToken),
+            URLQueryItem(name: "subject_token_type", value: "urn:ietf:params:oauth:token-type:access_token")
         ]
         request.httpBody = urlParser.percentEncodedQuery?.data(using: .utf8)
         return request

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -93,10 +93,10 @@ extension NetworkClientTests {
         XCTAssertEqual(httpMethod, "POST")
         let bodyData = try XCTUnwrap(firstRequest.httpBodyData())
         let body = try XCTUnwrap(String(data: bodyData, encoding: .utf8)?.split(separator: "&"))
-        XCTAssertEqual(body[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+        XCTAssertEqual(body[0], "grant_type=urn:ietf:params:oauth:grant-type:token-exchange")
         XCTAssertEqual(body[1], "scope=testScope")
-        XCTAssertEqual(body[2], "subject-token=testBearerToken")
-        XCTAssertEqual(body[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+        XCTAssertEqual(body[2], "subject_token=testBearerToken")
+        XCTAssertEqual(body[3], "subject_token_type=urn:ietf:params:oauth:token-type:access_token")
         
         let secondRequest = try XCTUnwrap(MockURLProtocol.requests.last)
         let bearerToken = secondRequest.value(forHTTPHeaderField: "Authorization")

--- a/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
+++ b/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
@@ -24,10 +24,10 @@ extension URLRequestTests {
         XCTAssertEqual(tokenRequest.url, URL(string: "https://www.google.com"))
         XCTAssertEqual(contentTypeHeader, "application/x-www-form-urlencoded")
         XCTAssertEqual(httpMethod, "POST")
-        XCTAssertEqual(body[0], "grant-type=urn:ietf:params:oauth:grant-type:token-exchange")
+        XCTAssertEqual(body[0], "grant_type=urn:ietf:params:oauth:grant-type:token-exchange")
         XCTAssertEqual(body[1], "scope=testScope")
-        XCTAssertEqual(body[2], "subject-token=tesSubjectToken")
-        XCTAssertEqual(body[3], "subject-token-type=urn:ietf:params:oauth:token-type:access_token")
+        XCTAssertEqual(body[2], "subject_token=tesSubjectToken")
+        XCTAssertEqual(body[3], "subject_token_type=urn:ietf:params:oauth:token-type:access_token")
     }
     
     func test_authorized() throws {


### PR DESCRIPTION
# DCMAW-8805: iOS | Authenticated Requests | Authenticated request to Hello World API (Successful Request & Unsuccessful Token Exchange)

When making a request to the STS /token endpoint the form encoded body properties should have underscores between their property names, rather than hyphens.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
