### PR TITLE
feat: making token property public

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Run Quality Report
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       contents: write
 
@@ -24,7 +24,7 @@ jobs:
 
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.2.app
+          sudo xcode-select -s /Applications/Xcode_16.1.app
 
       - name: Build and Test
         run: |

--- a/Sources/TokenGeneration/JWT/JWTGenerator.swift
+++ b/Sources/TokenGeneration/JWT/JWTGenerator.swift
@@ -10,7 +10,7 @@ public struct JWTGenerator {
         self.signingService = signingService
     }
     
-    var token: String {
+    public var token: String {
         get throws {
             guard let headerData = try? JSONSerialization.data(withJSONObject: jwtRepresentation.header),
                   let payloadData = try? JSONSerialization.data(withJSONObject: jwtRepresentation.payload) else {


### PR DESCRIPTION
# fix: making token property public

Making the `JWTGeneration.token` property public was missed in #31.
The merge workflow also wasn't updated to match the pull request workflow in regard to runner OS and Xcode version needed for using SwiftTesting.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
