### PR TITLE
fix: JWTRepresentation public initialiser

### DIFF
--- a/Sources/TokenGeneration/JWT/JWTRepresentation.swift
+++ b/Sources/TokenGeneration/JWT/JWTRepresentation.swift
@@ -2,7 +2,7 @@ public struct JWTRepresentation {
     let header: [String: Any]
     let payload: [String: Any]
     
-    public init(header: [String : Any], payload: [String : Any]) {
+    public init(header: [String: Any], payload: [String: Any]) {
         self.header = header
         self.payload = payload
     }

--- a/Sources/TokenGeneration/JWT/JWTRepresentation.swift
+++ b/Sources/TokenGeneration/JWT/JWTRepresentation.swift
@@ -1,4 +1,9 @@
 public struct JWTRepresentation {
     let header: [String: Any]
     let payload: [String: Any]
+    
+    public init(header: [String : Any], payload: [String : Any]) {
+        self.header = header
+        self.payload = payload
+    }
 }


### PR DESCRIPTION
# fix: JWTRepresentation public initialiser

Making the `JWTRepresentation` initialiser public in #31 was missed. This PR fixes that access control issue.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
