### PR TITLE
fix: JWT generation steps

### DIFF
--- a/Sources/TokenGeneration/JWT/JWTGenerator.swift
+++ b/Sources/TokenGeneration/JWT/JWTGenerator.swift
@@ -17,17 +17,13 @@ public struct JWTGenerator {
                 throw JWTGeneratorError.cantCreateJSONData
             }
             
-            guard let headerJSONString = String(data: headerData, encoding: .utf8),
-                  let payloadJSONString = String(data: payloadData, encoding: .utf8) else {
-                throw JWTGeneratorError.cantCreateJSONString
-            }
-            
-            let signableJSONString = headerJSONString + "." + payloadJSONString
-            let dataToSign = Data(signableJSONString.utf8)
-            let signature = try signingService.sign(data: dataToSign)
-            
             let encodedHeader = headerData.base64URLEncodedString
             let encodedPayload = payloadData.base64URLEncodedString
+            
+            let signableJSONString = encodedHeader + "." + encodedPayload
+            let dataToSign = Data(signableJSONString.utf8)
+            let signature = try signingService.sign(data: dataToSign)
+
             let encodedSignature = signature.base64URLEncodedString
             
             return "\(encodedHeader).\(encodedPayload).\(encodedSignature)"

--- a/Sources/TokenGeneration/JWT/JWTGenerator.swift
+++ b/Sources/TokenGeneration/JWT/JWTGenerator.swift
@@ -12,21 +12,21 @@ public struct JWTGenerator {
     
     public var token: String {
         get throws {
-            guard let headerData = try? JSONSerialization.data(withJSONObject: jwtRepresentation.header),
-                  let payloadData = try? JSONSerialization.data(withJSONObject: jwtRepresentation.payload) else {
+            guard let headerJSONData = try? JSONSerialization.data(withJSONObject: jwtRepresentation.header),
+                  let payloadJSONData = try? JSONSerialization.data(withJSONObject: jwtRepresentation.payload) else {
                 throw JWTGeneratorError.cantCreateJSONData
             }
             
-            let encodedHeader = headerData.base64URLEncodedString
-            let encodedPayload = payloadData.base64URLEncodedString
+            let encodedHeaderJSONData = headerJSONData.base64URLEncodedString
+            let encodedPayloadJSONData = payloadJSONData.base64URLEncodedString
             
-            let signableJSONString = encodedHeader + "." + encodedPayload
-            let dataToSign = Data(signableJSONString.utf8)
+            let signableJSONData = encodedHeaderJSONData + "." + encodedPayloadJSONData
+            let dataToSign = Data(signableJSONData.utf8)
             let signature = try signingService.sign(data: dataToSign)
 
             let encodedSignature = signature.base64URLEncodedString
             
-            return "\(encodedHeader).\(encodedPayload).\(encodedSignature)"
+            return "\(encodedHeaderJSONData).\(encodedPayloadJSONData).\(encodedSignature)"
         }
     }
 }

--- a/Tests/TokenGenerationTests/JWTGeneratorTests.swift
+++ b/Tests/TokenGenerationTests/JWTGeneratorTests.swift
@@ -68,8 +68,8 @@ struct JWTGeneratorTests {
     }
     
     private func createSignatureFromJSON(headerJSON: Data, payloadJSON: Data) throws -> Data {
-        let headerJSONString = try #require(String(data: headerJSON, encoding: .utf8))
-        let payloadJSONString = try #require(String(data: payloadJSON, encoding: .utf8))
-        return Data((headerJSONString + "." + payloadJSONString).utf8)
+        let encodedHeaderJSON = headerJSON.base64URLEncodedString
+        let encodedPayloadJSON = payloadJSON.base64URLEncodedString
+        return Data((encodedHeaderJSON + "." + encodedPayloadJSON).utf8)
     }
 }


### PR DESCRIPTION
# fix: JWT generation steps

The `JWTGenerator` has been generating the JWT by converting header and payload dictionaries to JSON data, converting that JSON data to a string and concatenating the two with a "." before signing it.
This is incorrect and the process should be base64url encoding the header and payload JSON data and then concatenating by a "." before signing it. Creating a JSON string of the header and payload JSON data is an unnecessary step.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
