### PR TITLE
feat: DCMAW-15483 conform ServerError to CustomNSError

### DIFF
--- a/Sources/Networking/ServerError.swift
+++ b/Sources/Networking/ServerError.swift
@@ -9,3 +9,5 @@ public struct ServerError: ErrorWithCode {
     public let endpoint: String?
     public let errorCode: Int
 }
+
+extension ServerError: CustomNSError {}

--- a/Sources/Networking/UserAgent.swift
+++ b/Sources/Networking/UserAgent.swift
@@ -78,6 +78,10 @@ struct UserAgent: CustomStringConvertible {
     
     // MARK: Creating the UserAgent header string
     var description: String {
-        "\(appInfo) \(deviceModel) \(osVersion) \(cfNetwork) \(darwin)"
+        return [appInfo, deviceModel, osVersion, cfNetwork, darwin]
+            .map {
+                $0.replacingOccurrences(of: " ", with: "_")
+            }
+            .joined(separator: " ")
     }
 }

--- a/Sources/Networking/UserAgent.swift
+++ b/Sources/Networking/UserAgent.swift
@@ -78,10 +78,6 @@ struct UserAgent: CustomStringConvertible {
     
     // MARK: Creating the UserAgent header string
     var description: String {
-        return [appInfo, deviceModel, osVersion, cfNetwork, darwin]
-            .map {
-                $0.replacingOccurrences(of: " ", with: "_")
-            }
-            .joined(separator: " ")
+        return "\(appInfo) \(deviceModel) \(osVersion) \(cfNetwork) \(darwin)"
     }
 }

--- a/Sources/Networking/UserAgent.swift
+++ b/Sources/Networking/UserAgent.swift
@@ -78,6 +78,6 @@ struct UserAgent: CustomStringConvertible {
     
     // MARK: Creating the UserAgent header string
     var description: String {
-        return "\(appInfo) \(deviceModel) \(osVersion) \(cfNetwork) \(darwin)"
+        "\(appInfo) \(deviceModel) \(osVersion) \(cfNetwork) \(darwin)"
     }
 }

--- a/Tests/NetworkingTests/ServerErrorTests.swift
+++ b/Tests/NetworkingTests/ServerErrorTests.swift
@@ -1,23 +1,24 @@
 @testable import Networking
-import XCTest
+import Foundation
+import Testing
 
-final class ServerErrorTests: XCTestCase {
-    private var sut: ServerError!
-
-    override func setUp() {
-        super.setUp()
-        sut = ServerError(endpoint: "testendpoint", errorCode: 200)
+struct ServerErrorTests {
+    @Test("ServerError params")
+    func serverError_params() throws {
+        let sut = ServerError(endpoint: "testendpoint", errorCode: 200)
+        
+        #expect(sut.endpoint == "testendpoint")
+        #expect(sut.errorCode.description == "200")
+        #expect(sut.reason == "server")
+        #expect(sut.hash == "83766358f64858b51afb745bbdde91bb")
     }
     
-    override func tearDown() {
-        sut = nil
-        super.tearDown()
-    }
-    
-    func test_ServerError_params() throws {
-        XCTAssertEqual(sut.endpoint, "testendpoint")
-        XCTAssertEqual(sut.errorCode.description, "200")
-        XCTAssertEqual(sut.reason, "server")
-        XCTAssertEqual(sut.hash, "83766358f64858b51afb745bbdde91bb")
+    @Test("ServerError as CustomNSError")
+    func castAsCustomNSError() throws {
+        let sut = ServerError(endpoint: "testendpoint", errorCode: 200)
+        
+        let nsError = sut as CustomNSError
+        
+        #expect(nsError.errorCode == 200)
     }
 }

--- a/Tests/NetworkingTests/ServerErrorTests.swift
+++ b/Tests/NetworkingTests/ServerErrorTests.swift
@@ -1,5 +1,5 @@
-@testable import Networking
 import Foundation
+@testable import Networking
 import Testing
 
 struct ServerErrorTests {


### PR DESCRIPTION
# Add `ServerError` conformance to `CustomNSError`

This change is so that the `errorCode` can be easily accessed outside of Networking.

https://govukverify.atlassian.net/browse/DCMAW-15483

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
