### PR TITLE
feat: DCMAW-18770 mitigate risk of script injection

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -59,11 +59,13 @@ jobs:
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
-            -Dsonar.pullrequest.branch=${{github.head_ref}} \
-            -Dsonar.pullrequest.base=${{github.base_ref}}
+            -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" \
+            -Dsonar.pullrequest.base="${GITHUB_BASE_REF}"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
 
       - name: Check SonarCloud Results
         uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # pin@v1.2.0


### PR DESCRIPTION
# [Mitigate the risk of a script injection by using an intermediate environment variable](https://govukverify.atlassian.net/browse/DCMAW-18770)

The current GitHub workflow uses a [github context variable ](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context) to evaluate the the `head_ref` or _source branch_ of the pull request and the `base_ref` or _target branch_ of the pull request in a workflow run. 

<img width="732" height="217" alt="Screenshot 2026-03-19 at 09 07 05" src="https://github.com/user-attachments/assets/72074795-742e-4702-b50e-cf60d5761b9a" />

As explained at https://github.com/govuk-one-login/mobile-ios-authentication/pull/91

## Where to focus the review
* Do the changes in the `pull-request.yml` workflow mitigate the risk as described?

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
