### PR TITLE
fix!: DCMAW-19419 Replace Combine with async/await in NetworkClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "Networking",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(name: "Networking", targets: ["Networking"]),
         .library(name: "MockNetworking", targets: ["MockNetworking"]),

--- a/Sources/MockNetworking/MockURLProtocol.swift
+++ b/Sources/MockNetworking/MockURLProtocol.swift
@@ -4,12 +4,21 @@ import Foundation
 ///
 /// Used for mocking a url response for unit testing.
 public final class MockURLProtocol: URLProtocol {
+    enum MockURLProtocolError: String, Error {
+        case noHandlerSet = "⚠️ Remember to set a handler closure when using MockURLProtocol"
+    }
+    
     public private(set) static var requests: [URLRequest] = []
-    public static var handler: (() throws -> (Data, URLResponse))?
+    public static var handler: (() throws -> (data: Data, response: URLResponse)) = defaultHandler
+    
+    static let defaultHandler: (() throws -> (Data, URLResponse)) = {
+        assertionFailure(MockURLProtocolError.noHandlerSet.rawValue)
+        throw MockURLProtocolError.noHandlerSet
+    }
     
     public static func clear() {
         requests = []
-        handler = nil
+        handler = defaultHandler
     }
     
     public override static func canonicalRequest(for request: URLRequest) -> URLRequest {
@@ -22,22 +31,17 @@ public final class MockURLProtocol: URLProtocol {
     }
     
     public override func startLoading() {
-        guard let handler = Self.handler else {
-            assertionFailure("Remember to set a handler closure when using MockURLProtocol")
-            return
-        }
-        
         do {
-            let (data, response) = try handler()
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
-            client?.urlProtocol(self, didLoad: data)
+            let handlerResult = try Self.handler()
+            
+            client?.urlProtocol(self, didReceive: handlerResult.response, cacheStoragePolicy: .allowed)
+            client?.urlProtocol(self, didLoad: handlerResult.data)
             client?.urlProtocolDidFinishLoading(self)
             
         } catch {
             client?.urlProtocol(self, didFailWithError: error)
         }
     }
-
     
     public override func stopLoading() {
         // This method is unused in the mock currently

--- a/Sources/MockNetworking/MockURLProtocol.swift
+++ b/Sources/MockNetworking/MockURLProtocol.swift
@@ -4,10 +4,6 @@ import Foundation
 ///
 /// Used for mocking a url response for unit testing.
 public final class MockURLProtocol: URLProtocol {
-    enum MockURLProtocolError: String, Error {
-        case noHandlerSet = "Remember to set a handler closure when using MockURLProtocol"
-    }
-    
     public private(set) static var requests: [URLRequest] = []
     public static var handler: (() throws -> (Data, URLResponse))?
     
@@ -26,19 +22,20 @@ public final class MockURLProtocol: URLProtocol {
     }
     
     public override func startLoading() {
+        guard let handler = Self.handler else {
+            assertionFailure("Remember to set a handler closure when using MockURLProtocol")
+            return
+        }
+        
         do {
-            guard let handler = Self.handler else {
-                assertionFailure(MockURLProtocolError.noHandlerSet.rawValue)
-                throw MockURLProtocolError.noHandlerSet
-            }
             let (data, response) = try handler()
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
             client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+            
         } catch {
             client?.urlProtocol(self, didFailWithError: error)
         }
-        
-        client?.urlProtocolDidFinishLoading(self)
     }
 
     

--- a/Sources/MockNetworking/MockURLProtocol.swift
+++ b/Sources/MockNetworking/MockURLProtocol.swift
@@ -4,6 +4,10 @@ import Foundation
 ///
 /// Used for mocking a url response for unit testing.
 public final class MockURLProtocol: URLProtocol {
+    enum MockURLProtocolError: String, Error {
+        case noHandlerSet = "Remember to set a handler closure when using MockURLProtocol"
+    }
+    
     public private(set) static var requests: [URLRequest] = []
     public static var handler: (() throws -> (Data, URLResponse))?
     
@@ -23,16 +27,20 @@ public final class MockURLProtocol: URLProtocol {
     
     public override func startLoading() {
         do {
-            if let (data, response) = try Self.handler?() {
-                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
-                client?.urlProtocol(self, didLoad: data)
+            guard let handler = Self.handler else {
+                assertionFailure(MockURLProtocolError.noHandlerSet.rawValue)
+                throw MockURLProtocolError.noHandlerSet
             }
+            let (data, response) = try handler()
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
+            client?.urlProtocol(self, didLoad: data)
         } catch {
             client?.urlProtocol(self, didFailWithError: error)
         }
         
         client?.urlProtocolDidFinishLoading(self)
     }
+
     
     public override func stopLoading() {
         // This method is unused in the mock currently

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 /// NetworkClient
@@ -8,7 +7,6 @@ public final class NetworkClient {
     public var authorizationProvider: AuthorizationProvider?
 
     private let session: URLSession
-    private var cancellables: Set<AnyCancellable> = []
     
     #if DEBUG
         var debugSession: URLSession {
@@ -46,40 +44,22 @@ public final class NetworkClient {
     ///   - request: ``URLRequest`` for the network request
     /// - Returns: ``Data`` the response data from the endpoint
     public func makeRequest(_ request: URLRequest) async throws -> Data {
-        try await withCheckedThrowingContinuation { continuation in
-            makeRequest(request) { response in
-                switch response {
-                case .success((let data, let response as HTTPURLResponse)):
-                    #if DEBUG
-                    print("network status code: \(response.statusCode)")
-                    print("absolute path", response.url?.absoluteString ?? "")
-                    print("last path component", response.url?.pathComponents.last ?? "")
-                    #endif
-                    guard response.isSuccessful else {
-                        continuation.resume(throwing: ServerError(endpoint: request.url?.pathComponents.last,
-                                                                  errorCode: response.statusCode,
-                                                                  response: data))
-                        return
-                    }
-                    continuation.resume(returning: data)
-                case .success((let data, _)):
-                    continuation.resume(returning: data)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+        let (data, response) = try await session.data(for: request)
+        
+        if let httpResponse = response as? HTTPURLResponse {
+            #if DEBUG
+            print("network status code: \(httpResponse.statusCode)")
+            print("absolute path", httpResponse.url?.absoluteString ?? "")
+            print("last path component", httpResponse.url?.pathComponents.last ?? "")
+            #endif
+            guard httpResponse.isSuccessful else {
+                throw ServerError(endpoint: request.url?.pathComponents.last,
+                                  errorCode: httpResponse.statusCode,
+                                  response: data)
             }
         }
-    }
-    
-    private func makeRequest(_ request: URLRequest,
-                             completion: @escaping (Result<(Data, URLResponse), Error>) -> Void) {
-        session.dataTaskPublisher(for: request).sink {
-            if case .failure(let error) = $0 {
-                completion(.failure(error))
-            }
-        } receiveValue: {
-            completion(.success(($0, $1)))
-        }.store(in: &cancellables)
+        
+        return data
     }
 
     /// `makeAuthorizedRequest` method for making authorized network requests has three parameters and returns `Data`


### PR DESCRIPTION
# DCMAW-19419 Remove combine to make safe for concurrent requests

- Remove dataTaskPublisher and cancellables Set to fix concurrent access crash
- Use URLSession.data(for:) async API instead
- Bump minimum platform to iOS 15
- 
https://govukverify.atlassian.net/browse/DCMAW-19419

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
