### PR TITLE
feat: DCMAW-20186 New Request Builder pattern 

### DIFF
--- a/Sources/Networking/Attestation/ClientAttestationProvider.swift
+++ b/Sources/Networking/Attestation/ClientAttestationProvider.swift
@@ -1,5 +1,5 @@
 /// Protocol for passing the client attestation headers
 public protocol ClientAttestationProvider {
-    func fetchClientAttestations() async throws -> [String: String]
+    func fetchClientAttestation() async throws -> [String: String]
     func fetchDPoP() throws -> [String: String]
 }

--- a/Sources/Networking/Attestation/ClientAttestationProvider.swift
+++ b/Sources/Networking/Attestation/ClientAttestationProvider.swift
@@ -1,0 +1,5 @@
+/// Protocol for passing the client attestation headers
+public protocol ClientAttestationProvider {
+    func fetchClientAttestations() async throws -> [String: String]
+    func fetchDPoP() throws -> [String: String]
+}

--- a/Sources/Networking/Attestation/ClientAttestationProvider.swift
+++ b/Sources/Networking/Attestation/ClientAttestationProvider.swift
@@ -1,5 +1,4 @@
 /// Protocol for passing the client attestation headers
 public protocol ClientAttestationProvider {
     func fetchClientAttestation() async throws -> [String: String]
-    func fetchDPoP() throws -> [String: String]
 }

--- a/Sources/Networking/Attestation/DPoPProvider.swift
+++ b/Sources/Networking/Attestation/DPoPProvider.swift
@@ -1,0 +1,4 @@
+/// Protocol for passing the dPoP headers
+public protocol DPoPProvider {
+    func fetchDPoP() throws -> [String: String]
+}

--- a/Sources/Networking/Attestation/URLRequest+Attestation.swift
+++ b/Sources/Networking/Attestation/URLRequest+Attestation.swift
@@ -1,20 +1,9 @@
 import Foundation
 
 extension URLRequest {
-    func clientAttestation(with clientAttestationValues: [String: String]) -> Self {
+    func setHeaderValues(_ headerList: [String: String]) -> Self {
         var request = self
-        for (key, value) in clientAttestationValues {
-            request.setValue(
-                value,
-                forHTTPHeaderField: key
-            )
-        }
-        return request
-    }
-    
-    func dPoPAssertion(with dPoPValues: [String: String]) -> Self {
-        var request = self
-        for (key, value) in dPoPValues {
+        for (key, value) in headerList {
             request.setValue(
                 value,
                 forHTTPHeaderField: key

--- a/Sources/Networking/Attestation/URLRequest+Attestation.swift
+++ b/Sources/Networking/Attestation/URLRequest+Attestation.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension URLRequest {
+    func clientAttestation(with clientAttestationValues: [String: String]) -> Self {
+        var request = self
+        for (key, value) in clientAttestationValues {
+            request.setValue(
+                value,
+                forHTTPHeaderField: key
+            )
+        }
+        return request
+    }
+    
+    func dPoPAssertion(with dPoPValues: [String: String]) -> Self {
+        var request = self
+        for (key, value) in dPoPValues {
+            request.setValue(
+                value,
+                forHTTPHeaderField: key
+            )
+        }
+        return request
+    }
+}

--- a/Sources/Networking/Authorization/AuthorizationProvider.swift
+++ b/Sources/Networking/Authorization/AuthorizationProvider.swift
@@ -1,3 +1,4 @@
+// TODO: DCMAW-20369 Remove deprecated typealias
 @available(*, deprecated, renamed: "AuthorizationProvider")
 typealias AuthenticationProvider = AuthorizationProvider
 

--- a/Sources/Networking/Authorization/AuthorizationProvider.swift
+++ b/Sources/Networking/Authorization/AuthorizationProvider.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 @available(*, deprecated, renamed: "AuthorizationProvider")
 typealias AuthenticationProvider = AuthorizationProvider
 

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -3,9 +3,12 @@ import Foundation
 /// NetworkClient
 ///
 /// `NetworkClient` is a class with one public async throwing method called `makeRequest` which handles network requests and returns `Data`.
-public final class NetworkClient {
+///
+///  NetworkClient wrappers need to extend NetworkClientProtocol so that the execute() on the builder goes through the makeRequest they are implementing.
+public final class NetworkClient: NetworkClientProtocol {
     public var authorizationProvider: AuthorizationProvider?
-
+    public var clientAttestationProvider: ClientAttestationProvider?
+    
     private let session: URLSession
     
     #if DEBUG
@@ -38,11 +41,81 @@ public final class NetworkClient {
         session = .init(configuration: configuration)
     }
     
+    /// `makeRequest` method for making network requests has a single parameter of type `NetworkRequest` and returns `Data`
+    ///  Meant to be used through the .execute() function and not to be called directly
+    ///  Example:
+    ///  networkClient.request(URLRequest).withAuthentication().withAttestation().withDPoP().execute()
+    ///
+    /// - Parameters:
+    ///   - request: ``NetworkRequest`` for the network request
+    /// - Returns: ``Data`` the response data from the endpoint
+    public func makeRequest(_ request: NetworkRequest) async throws -> Data {
+        let urlRequest = try await setUp(request: request)
+ 
+        let (data, response) = try await session.data(for: urlRequest)
+        
+        if let httpResponse = response as? HTTPURLResponse {
+            #if DEBUG
+            print("network status code: \(httpResponse.statusCode)")
+            print("absolute path", httpResponse.url?.absoluteString ?? "")
+            print("last path component", httpResponse.url?.pathComponents.last ?? "")
+            #endif
+            guard httpResponse.isSuccessful else {
+                throw ServerError(endpoint: urlRequest.url?.pathComponents.last,
+                                  errorCode: httpResponse.statusCode,
+                                  response: data)
+            }
+        }
+        
+        return data
+    }
+    
+    private func setUp(request: NetworkRequest) async throws -> URLRequest {
+        var urlRequest = request.urlRequest
+        
+        /// Set auth scope if present
+        if let scope = request.authScope {
+            guard let authorizationProvider else {
+                assertionFailure("Authorization provider not present")
+                throw NetworkClientError.authorizationProviderNotPresent
+            }
+            let authorizationToken = try await authorizationProvider
+                .fetchToken(withScope: scope)
+            urlRequest = urlRequest.authorized(with: authorizationToken)
+        }
+        
+        /// Set client attestation if present
+        if request.requiresClientAttestations {
+            guard let clientAttestationProvider else {
+                assertionFailure("Client attestation provider not present")
+                throw NetworkClientError.clientAttestationProviderNotPresent
+            }
+            let attestationParameters = try await clientAttestationProvider.fetchClientAttestations()
+            urlRequest = urlRequest.clientAttestation(with: attestationParameters)
+        }
+        
+        /// Set DPoP if present
+        if request.requiresDPoP {
+            guard let clientAttestationProvider else {
+                assertionFailure("Client attestation provider not present")
+                throw NetworkClientError.clientAttestationProviderNotPresent
+            }
+            let dPoP = try clientAttestationProvider.fetchDPoP()
+            urlRequest = urlRequest.dPoPAssertion(with: dPoP)
+        }
+        
+        return urlRequest
+    }
+}
+
+// TODO: DCMAW-20369 Remove deprecated methods
+extension NetworkClient {
     /// `makeRequest` method for making network requests has a single parameter of type `URLRequest` and returns `Data`
     ///
     /// - Parameters:
     ///   - request: ``URLRequest`` for the network request
     /// - Returns: ``Data`` the response data from the endpoint
+    @available(*, deprecated, message: "Use .request().execute() instead")
     public func makeRequest(_ request: URLRequest) async throws -> Data {
         let (data, response) = try await session.data(for: request)
         
@@ -69,6 +142,7 @@ public final class NetworkClient {
     ///   - scope: ``String`` for the scope of the authenticated token
     ///   - request: ``URLRequest`` for the authorized network request
     /// - Returns: ``Data`` the response data from the endpoint
+    @available(*, deprecated, message: "Use .request().withAuthorization(scope:).execute() instead")
     public func makeAuthorizedRequest(
         scope: String,
         request: URLRequest

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -8,6 +8,7 @@ import Foundation
 public final class NetworkClient: NetworkClientProtocol {
     public var authorizationProvider: AuthorizationProvider?
     public var clientAttestationProvider: ClientAttestationProvider?
+    public var dPoPProvider: DPoPProvider?
     
     private let session: URLSession
     
@@ -73,7 +74,7 @@ public final class NetworkClient: NetworkClientProtocol {
     private func configureRequestHeaders(for request: NetworkRequest) async throws -> URLRequest {
         var urlRequest = request.urlRequest
         
-        /// Set auth scope if present
+        /// Add authorization header if auth scope provided
         if let scope = request.authScope {
             guard let authorizationProvider else {
                 assertionFailure("Authorization provider not present")
@@ -83,7 +84,7 @@ public final class NetworkClient: NetworkClientProtocol {
             urlRequest = urlRequest.authorized(with: authorizationToken)
         }
         
-        /// Set client attestation if present
+        /// Add client attestation headers if required
         if request.requiresClientAttestation {
             guard let clientAttestationProvider else {
                 assertionFailure("Client attestation provider not present")
@@ -93,13 +94,13 @@ public final class NetworkClient: NetworkClientProtocol {
             urlRequest = urlRequest.setHeaderValues(attestationHeaders)
         }
         
-        /// Set DPoP if present
+        /// Add DPoP header if required
         if request.requiresDPoP {
-            guard let clientAttestationProvider else {
-                assertionFailure("Client attestation provider not present")
-                throw NetworkClientError.clientAttestationProviderNotPresent
+            guard let dPoPProvider else {
+                assertionFailure("DPoP provider not present")
+                throw NetworkClientError.dPoPProviderNotPresent
             }
-            let dPoPHeaders = try clientAttestationProvider.fetchDPoP()
+            let dPoPHeaders = try dPoPProvider.fetchDPoP()
             urlRequest = urlRequest.setHeaderValues(dPoPHeaders)
         }
         

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -50,7 +50,7 @@ public final class NetworkClient: NetworkClientProtocol {
     ///   - request: ``NetworkRequest`` for the network request
     /// - Returns: ``Data`` the response data from the endpoint
     public func makeRequest(_ request: NetworkRequest) async throws -> Data {
-        let urlRequest = try await setUp(request: request)
+        let urlRequest = try await configureRequestHeaders(for: request)
  
         let (data, response) = try await session.data(for: urlRequest)
         
@@ -70,7 +70,7 @@ public final class NetworkClient: NetworkClientProtocol {
         return data
     }
     
-    private func setUp(request: NetworkRequest) async throws -> URLRequest {
+    private func configureRequestHeaders(for request: NetworkRequest) async throws -> URLRequest {
         var urlRequest = request.urlRequest
         
         /// Set auth scope if present
@@ -79,8 +79,7 @@ public final class NetworkClient: NetworkClientProtocol {
                 assertionFailure("Authorization provider not present")
                 throw NetworkClientError.authorizationProviderNotPresent
             }
-            let authorizationToken = try await authorizationProvider
-                .fetchToken(withScope: scope)
+            let authorizationToken = try await authorizationProvider.fetchToken(withScope: scope)
             urlRequest = urlRequest.authorized(with: authorizationToken)
         }
         

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -44,7 +44,7 @@ public final class NetworkClient: NetworkClientProtocol {
     /// `makeRequest` method for making network requests has a single parameter of type `NetworkRequest` and returns `Data`
     ///  Meant to be used through the .execute() function and not to be called directly
     ///  Example:
-    ///  networkClient.request(URLRequest).withAuthentication().withAttestation().withDPoP().execute()
+    ///  networkClient.request(URLRequest).withAuthentication().withClientAttestation().withDPoP().execute()
     ///
     /// - Parameters:
     ///   - request: ``NetworkRequest`` for the network request
@@ -89,8 +89,8 @@ public final class NetworkClient: NetworkClientProtocol {
                 assertionFailure("Client attestation provider not present")
                 throw NetworkClientError.clientAttestationProviderNotPresent
             }
-            let attestationParameters = try await clientAttestationProvider.fetchClientAttestation()
-            urlRequest = urlRequest.clientAttestation(with: attestationParameters)
+            let attestationHeaders = try await clientAttestationProvider.fetchClientAttestation()
+            urlRequest = urlRequest.setHeaderValues(attestationHeaders)
         }
         
         /// Set DPoP if present
@@ -99,8 +99,8 @@ public final class NetworkClient: NetworkClientProtocol {
                 assertionFailure("Client attestation provider not present")
                 throw NetworkClientError.clientAttestationProviderNotPresent
             }
-            let dPoP = try clientAttestationProvider.fetchDPoP()
-            urlRequest = urlRequest.dPoPAssertion(with: dPoP)
+            let dPoPHeaders = try clientAttestationProvider.fetchDPoP()
+            urlRequest = urlRequest.setHeaderValues(dPoPHeaders)
         }
         
         return urlRequest

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -84,12 +84,12 @@ public final class NetworkClient: NetworkClientProtocol {
         }
         
         /// Set client attestation if present
-        if request.requiresClientAttestations {
+        if request.requiresClientAttestation {
             guard let clientAttestationProvider else {
                 assertionFailure("Client attestation provider not present")
                 throw NetworkClientError.clientAttestationProviderNotPresent
             }
-            let attestationParameters = try await clientAttestationProvider.fetchClientAttestations()
+            let attestationParameters = try await clientAttestationProvider.fetchClientAttestation()
             urlRequest = urlRequest.clientAttestation(with: attestationParameters)
         }
         

--- a/Sources/Networking/NetworkClientError.swift
+++ b/Sources/Networking/NetworkClientError.swift
@@ -1,3 +1,4 @@
 enum NetworkClientError: Error {
     case authorizationProviderNotPresent
+    case clientAttestationProviderNotPresent
 }

--- a/Sources/Networking/NetworkClientError.swift
+++ b/Sources/Networking/NetworkClientError.swift
@@ -1,4 +1,5 @@
 enum NetworkClientError: Error {
     case authorizationProviderNotPresent
     case clientAttestationProviderNotPresent
+    case dPoPProviderNotPresent
 }

--- a/Sources/Networking/NetworkRequest.swift
+++ b/Sources/Networking/NetworkRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Enables the NetworkClient and RequestBuilder to work together
+public struct NetworkRequest {
+    public var urlRequest: URLRequest
+    public var authScope: String?
+    public var requiresClientAttestations: Bool = false
+    public var requiresDPoP: Bool = false
+}

--- a/Sources/Networking/NetworkRequest.swift
+++ b/Sources/Networking/NetworkRequest.swift
@@ -4,6 +4,6 @@ import Foundation
 public struct NetworkRequest {
     public var urlRequest: URLRequest
     public var authScope: String?
-    public var requiresClientAttestations: Bool = false
+    public var requiresClientAttestation: Bool = false
     public var requiresDPoP: Bool = false
 }

--- a/Sources/Networking/Protocols/NetworkClientProtocol.swift
+++ b/Sources/Networking/Protocols/NetworkClientProtocol.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Make sure all NetworkClient Wrappers extend this protocol
+public protocol NetworkClientProtocol {
+    func request(_ request: URLRequest) -> RequestBuilder
+    func makeRequest(_ request: NetworkRequest) async throws -> Data
+}
+
+/// Provide implementation so that we don't have to repeat it on each NetworkClient
+extension NetworkClientProtocol {
+    /// Enables building a request that the builder can modify
+    public func request(_ request: URLRequest) -> RequestBuilder {
+        RequestBuilder(client: self, request: request)
+    }
+}

--- a/Sources/Networking/Protocols/NetworkClientProtocol.swift
+++ b/Sources/Networking/Protocols/NetworkClientProtocol.swift
@@ -6,9 +6,10 @@ public protocol NetworkClientProtocol {
     func makeRequest(_ request: NetworkRequest) async throws -> Data
 }
 
-/// Provide implementation so that we don't have to repeat it on each NetworkClient
+/// Default implementation so that it's not repeated on each NetworkClient wrapper
 extension NetworkClientProtocol {
-    /// Enables building a request that the builder can modify
+    /// Accepts a URLRequest and creates a RequestBuilder with reference to the NetworkClient itself.
+    /// The builder makes a NetworkRequest it can modify further, which will be used by makeRequest(), invoked from the .execute() on the builder.
     public func request(_ request: URLRequest) -> RequestBuilder {
         RequestBuilder(client: self, request: request)
     }

--- a/Sources/Networking/RequestBuilder.swift
+++ b/Sources/Networking/RequestBuilder.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Provides helper methods for constructing requests
+public final class RequestBuilder {
+    private var networkClient: NetworkClientProtocol
+    var request: NetworkRequest
+    
+    public init(client: NetworkClientProtocol, request: URLRequest) {
+        self.networkClient = client
+        self.request = NetworkRequest(urlRequest: request)
+    }
+    
+    public func withAuthentication(scope: String) -> RequestBuilder {
+        request.authScope = scope
+        return self
+    }
+    
+    public func withAttestation() -> RequestBuilder {
+        request.requiresClientAttestations = true
+        return self
+    }
+    
+    public func withDPoP() -> RequestBuilder {
+        request.requiresDPoP = true
+        return self
+    }
+    
+    public func execute() async throws -> Data {
+        try await networkClient.makeRequest(request)
+    }
+}

--- a/Sources/Networking/RequestBuilder.swift
+++ b/Sources/Networking/RequestBuilder.swift
@@ -16,7 +16,7 @@ public final class RequestBuilder {
     }
     
     public func withAttestation() -> RequestBuilder {
-        request.requiresClientAttestations = true
+        request.requiresClientAttestation = true
         return self
     }
     

--- a/Sources/Networking/RequestBuilder.swift
+++ b/Sources/Networking/RequestBuilder.swift
@@ -15,7 +15,7 @@ public final class RequestBuilder {
         return self
     }
     
-    public func withAttestation() -> RequestBuilder {
+    public func withClientAttestation() -> RequestBuilder {
         request.requiresClientAttestation = true
         return self
     }

--- a/Tests/NetworkingTests/Mocks/MockAuthenticationProvider.swift
+++ b/Tests/NetworkingTests/Mocks/MockAuthenticationProvider.swift
@@ -1,4 +1,3 @@
-import Foundation
 @testable import Networking
 
 final class MockAuthorizationProvider: AuthorizationProvider {

--- a/Tests/NetworkingTests/Mocks/MockClientAttestationProvider.swift
+++ b/Tests/NetworkingTests/Mocks/MockClientAttestationProvider.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Networking
 
 final class MockClientAttestationProvider: ClientAttestationProvider {
-    func fetchClientAttestations() async throws -> [String: String] {
+    func fetchClientAttestation() async throws -> [String: String] {
         return ["Test-Client-Attestation": "12345",
                 "Test-Client-Attestation-PoP": "12345"]
     }

--- a/Tests/NetworkingTests/Mocks/MockClientAttestationProvider.swift
+++ b/Tests/NetworkingTests/Mocks/MockClientAttestationProvider.swift
@@ -6,8 +6,4 @@ final class MockClientAttestationProvider: ClientAttestationProvider {
         return ["Test-Client-Attestation": "12345",
                 "Test-Client-Attestation-PoP": "12345"]
     }
-    
-    func fetchDPoP() throws -> [String: String] {
-        return ["Test-DPoP": "12345"]
-    }
 }

--- a/Tests/NetworkingTests/Mocks/MockClientAttestationProvider.swift
+++ b/Tests/NetworkingTests/Mocks/MockClientAttestationProvider.swift
@@ -1,0 +1,13 @@
+import Foundation
+@testable import Networking
+
+final class MockClientAttestationProvider: ClientAttestationProvider {
+    func fetchClientAttestations() async throws -> [String: String] {
+        return ["Test-Client-Attestation": "12345",
+                "Test-Client-Attestation-PoP": "12345"]
+    }
+    
+    func fetchDPoP() throws -> [String: String] {
+        return ["Test-DPoP": "12345"]
+    }
+}

--- a/Tests/NetworkingTests/Mocks/MockDPoPProvider.swift
+++ b/Tests/NetworkingTests/Mocks/MockDPoPProvider.swift
@@ -1,0 +1,8 @@
+import Foundation
+@testable import Networking
+
+final class MockDPoPProvider: DPoPProvider {
+    func fetchDPoP() throws -> [String: String] {
+        return ["Test-DPoP": "12345"]
+    }
+}

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -30,6 +30,7 @@ final class NetworkClientTests: XCTestCase {
         sut = nil
         clientAttestationProvider = nil
         authorizationProvider = nil
+        dPoPProvider = nil
         MockURLProtocol.clear()
         
         super.tearDown()

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -116,7 +116,7 @@ extension NetworkClientTests {
             (data, HTTPURLResponse(statusCode: 200))
         }
         // WHEN I make an attestation request
-        let returnedData = try await sut.request(.example).withAttestation().execute()
+        let returnedData = try await sut.request(.example).withClientAttestation().execute()
         XCTAssertEqual(returnedData, data)
         // THEN the attestation headers are attached
         let request = try XCTUnwrap(MockURLProtocol.requests.first)
@@ -154,7 +154,7 @@ extension NetworkClientTests {
             (data, HTTPURLResponse(statusCode: 200))
         }
         // WHEN I make a request with multiple headers
-        let returnedData = try await sut.request(.example).withAuthentication(scope: "testScope").withAttestation().withDPoP().execute()
+        let returnedData = try await sut.request(.example).withAuthentication(scope: "testScope").withClientAttestation().withDPoP().execute()
         XCTAssertEqual(returnedData, data)
         // THEN all the headers are attached
         let request = try XCTUnwrap(MockURLProtocol.requests.first)

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -67,11 +67,9 @@ extension NetworkClientTests {
         let firstResponse = try await sut.request(.example).execute()
         XCTAssertEqual(firstResponse, firstData)
         
-        
         let secondData = Data("{ testResult \(Date())}".utf8)
         
         MockURLProtocol.handler = {
-            
             (secondData, HTTPURLResponse(statusCode: 200))
         }
         
@@ -88,6 +86,7 @@ extension NetworkClientTests {
             _ = try await sut.request(.example).execute()
         } catch {
             XCTAssert(error is ServerError)
+            XCTAssertEqual((error as? ServerError)?.errorCode, 404)
         }
     }
     
@@ -186,11 +185,9 @@ extension NetworkClientTests {
         let firstResponse = try await sut.makeRequest(.example)
         XCTAssertEqual(firstResponse, firstData)
         
-        
         let secondData = Data("{ testResult \(Date())}".utf8)
         
         MockURLProtocol.handler = {
-            
             (secondData, HTTPURLResponse(statusCode: 200))
         }
         

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -8,6 +8,7 @@ final class NetworkClientTests: XCTestCase {
 
     private var authorizationProvider: MockAuthorizationProvider!
     private var clientAttestationProvider: MockClientAttestationProvider!
+    private var dPoPProvider: MockDPoPProvider!
 
     override func setUp() {
         super.setUp()
@@ -17,10 +18,12 @@ final class NetworkClientTests: XCTestCase {
 
         authorizationProvider = MockAuthorizationProvider()
         clientAttestationProvider = MockClientAttestationProvider()
+        dPoPProvider = MockDPoPProvider()
 
         sut = .init(configuration: configuration)
         sut.authorizationProvider = authorizationProvider
         sut.clientAttestationProvider = clientAttestationProvider
+        sut.dPoPProvider = dPoPProvider
     }
     
     override func tearDown() {

--- a/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Tests/NetworkingTests/NetworkClientTests.swift
@@ -7,6 +7,7 @@ final class NetworkClientTests: XCTestCase {
     private var sut: NetworkClient!
 
     private var authorizationProvider: MockAuthorizationProvider!
+    private var clientAttestationProvider: MockClientAttestationProvider!
 
     override func setUp() {
         super.setUp()
@@ -15,13 +16,19 @@ final class NetworkClientTests: XCTestCase {
         configuration.protocolClasses = [MockURLProtocol.self]
 
         authorizationProvider = MockAuthorizationProvider()
+        clientAttestationProvider = MockClientAttestationProvider()
 
         sut = .init(configuration: configuration)
         sut.authorizationProvider = authorizationProvider
+        sut.clientAttestationProvider = clientAttestationProvider
     }
     
     override func tearDown() {
         sut = nil
+        clientAttestationProvider = nil
+        authorizationProvider = nil
+        MockURLProtocol.clear()
+        
         super.tearDown()
     }
 }
@@ -57,6 +64,125 @@ extension NetworkClientTests {
             (firstData, HTTPURLResponse(statusCode: 200))
         }
         
+        let firstResponse = try await sut.request(.example).execute()
+        XCTAssertEqual(firstResponse, firstData)
+        
+        
+        let secondData = Data("{ testResult \(Date())}".utf8)
+        
+        MockURLProtocol.handler = {
+            
+            (secondData, HTTPURLResponse(statusCode: 200))
+        }
+        
+        let secondResponse = try await sut.request(.example).execute()
+        XCTAssertEqual(secondResponse, secondData)
+    }
+    
+    func test_makeRequest_returnsServerError() async throws {
+        MockURLProtocol.handler = {
+            (Data(), HTTPURLResponse(statusCode: 404))
+        }
+        
+        do {
+            _ = try await sut.request(.example).execute()
+        } catch {
+            XCTAssert(error is ServerError)
+        }
+    }
+    
+    func test_makeAuthorizedRequest_attachesAuthorizationToken() async throws {
+        // GIVEN I can connect to the backend server
+        let data = Data("{ testResult }".utf8)
+        MockURLProtocol.handler = {
+            (data, HTTPURLResponse(statusCode: 200))
+        }
+        // WHEN I make an authorized request
+        let returnedData = try await sut.request(.example).withAuthentication(scope: "testScope").execute()
+        XCTAssertEqual(returnedData, data)
+        // THEN the correct scope is requested
+        XCTAssertEqual(authorizationProvider.fetchedTokenScope, "testScope")
+        // AND the access token is attached
+        let request = try XCTUnwrap(MockURLProtocol.requests.first)
+        let bearerToken = request.value(forHTTPHeaderField: "Authorization")
+        XCTAssertEqual(bearerToken, "Bearer testBearerToken")
+        let userAgent = request.allHTTPHeaderFields?["User-Agent"]
+        XCTAssertEqual(userAgent, UserAgent().description)
+    }
+    
+    func test_makeAttestationRequest() async throws {
+        // GIVEN I can connect to the backend server
+        let data = Data("{ testResult }".utf8)
+        MockURLProtocol.handler = {
+            (data, HTTPURLResponse(statusCode: 200))
+        }
+        // WHEN I make an attestation request
+        let returnedData = try await sut.request(.example).withAttestation().execute()
+        XCTAssertEqual(returnedData, data)
+        // THEN the attestation headers are attached
+        let request = try XCTUnwrap(MockURLProtocol.requests.first)
+        let clientHeader = request.value(forHTTPHeaderField: "Test-Client-Attestation")
+        XCTAssertEqual(clientHeader, "12345")
+        let popHeader = request.value(forHTTPHeaderField: "Test-Client-Attestation-PoP")
+        XCTAssertEqual(popHeader, "12345")
+        
+        let userAgent = request.allHTTPHeaderFields?["User-Agent"]
+        XCTAssertEqual(userAgent, UserAgent().description)
+    }
+
+    func test_makeDPoPRequest() async throws {
+        // GIVEN I can connect to the backend server
+        let data = Data("{ testResult }".utf8)
+        MockURLProtocol.handler = {
+            (data, HTTPURLResponse(statusCode: 200))
+        }
+        // WHEN I make a dPoP request
+        let returnedData = try await sut.request(.example).withDPoP().execute()
+        XCTAssertEqual(returnedData, data)
+        // THEN the dPoP headers are attached
+        let request = try XCTUnwrap(MockURLProtocol.requests.first)
+        let dPoPHeader = request.value(forHTTPHeaderField: "Test-DPoP")
+        XCTAssertEqual(dPoPHeader, "12345")
+        
+        let userAgent = request.allHTTPHeaderFields?["User-Agent"]
+        XCTAssertEqual(userAgent, UserAgent().description)
+    }
+    
+    func test_makeAuthAndAttestationRequest() async throws {
+        // GIVEN I can connect to the backend server
+        let data = Data("{ testResult }".utf8)
+        MockURLProtocol.handler = {
+            (data, HTTPURLResponse(statusCode: 200))
+        }
+        // WHEN I make a request with multiple headers
+        let returnedData = try await sut.request(.example).withAuthentication(scope: "testScope").withAttestation().withDPoP().execute()
+        XCTAssertEqual(returnedData, data)
+        // THEN all the headers are attached
+        let request = try XCTUnwrap(MockURLProtocol.requests.first)
+        let dPoPHeader = request.value(forHTTPHeaderField: "Test-DPoP")
+        XCTAssertEqual(dPoPHeader, "12345")
+        let clientHeader = request.value(forHTTPHeaderField: "Test-Client-Attestation")
+        XCTAssertEqual(clientHeader, "12345")
+        let popHeader = request.value(forHTTPHeaderField: "Test-Client-Attestation-PoP")
+        XCTAssertEqual(popHeader, "12345")
+        let bearerToken = request.value(forHTTPHeaderField: "Authorization")
+        XCTAssertEqual(bearerToken, "Bearer testBearerToken")
+        
+        let userAgent = request.allHTTPHeaderFields?["User-Agent"]
+        XCTAssertEqual(userAgent, UserAgent().description)
+    }
+}
+
+// TODO: DCMAW-20369 Remove old tests when those methods are removed
+extension NetworkClientTests {
+    func test_makeRequest_returnsData_old() async throws {
+        let originalDate = Date()
+        let firstData = Data("{ testResult \(originalDate)}".utf8)
+        
+        MockURLProtocol.handler = {
+            (firstData, HTTPURLResponse(statusCode: 200))
+        }
+        
         let firstResponse = try await sut.makeRequest(.example)
         XCTAssertEqual(firstResponse, firstData)
         
@@ -72,7 +198,7 @@ extension NetworkClientTests {
         XCTAssertEqual(secondResponse, secondData)
     }
     
-    func test_makeRequest_returnsServerError() async throws {
+    func test_makeRequest_returnsServerError_old() async throws {
         MockURLProtocol.handler = {
             (Data(), HTTPURLResponse(statusCode: 404))
         }
@@ -84,7 +210,7 @@ extension NetworkClientTests {
         }
     }
     
-    func test_makeAuthorizedRequest_attachesAuthorizationToken() async throws {
+    func test_makeAuthorizedRequest_attachesAuthorizationToken_old() async throws {
         // GIVEN I can connect to the backend server
         let data = Data("{ testResult }".utf8)
         MockURLProtocol.handler = {

--- a/Tests/NetworkingTests/RequestBuilderTests.swift
+++ b/Tests/NetworkingTests/RequestBuilderTests.swift
@@ -2,7 +2,6 @@ import Foundation
 @testable import Networking
 import XCTest
 
-
 final class RequestBuilderTests: XCTestCase {
     // NetworkClient Mock
     private final class MockNetworkClient: NetworkClientProtocol {
@@ -30,7 +29,7 @@ final class RequestBuilderTests: XCTestCase {
     }
 }
 
-extension RequestBuilderTests {    
+extension RequestBuilderTests {
     func test_authentication_request() {
         // No auth scope set by default
         XCTAssertNil(sut.request.authScope)

--- a/Tests/NetworkingTests/RequestBuilderTests.swift
+++ b/Tests/NetworkingTests/RequestBuilderTests.swift
@@ -44,7 +44,7 @@ extension RequestBuilderTests {
         XCTAssertFalse(sut.request.requiresClientAttestation)
         
         // Make sure request has an authscope
-        let newSut = sut.withAttestation()
+        let newSut = sut.withClientAttestation()
         XCTAssertTrue(newSut.request.requiresClientAttestation)
         XCTAssertFalse(newSut.request.requiresDPoP)
     }
@@ -74,7 +74,7 @@ extension RequestBuilderTests {
         
         let requestBuilder = sut
             .withAuthentication(scope: "testAuth")
-            .withAttestation()
+            .withClientAttestation()
             .withDPoP()
         
         // Make sure request has all the set parameters

--- a/Tests/NetworkingTests/RequestBuilderTests.swift
+++ b/Tests/NetworkingTests/RequestBuilderTests.swift
@@ -41,11 +41,11 @@ extension RequestBuilderTests {
     
     func test_attestation_request() {
         // No auth scope set by default
-        XCTAssertFalse(sut.request.requiresClientAttestations)
+        XCTAssertFalse(sut.request.requiresClientAttestation)
         
         // Make sure request has an authscope
         let newSut = sut.withAttestation()
-        XCTAssertTrue(newSut.request.requiresClientAttestations)
+        XCTAssertTrue(newSut.request.requiresClientAttestation)
         XCTAssertFalse(newSut.request.requiresDPoP)
     }
     
@@ -56,7 +56,7 @@ extension RequestBuilderTests {
         // Make sure request has an authscope
         let newSut = sut.withDPoP()
         XCTAssertTrue(newSut.request.requiresDPoP)
-        XCTAssertFalse(newSut.request.requiresClientAttestations)
+        XCTAssertFalse(newSut.request.requiresClientAttestation)
     }
     
     func test_execute_request() async throws {
@@ -68,7 +68,7 @@ extension RequestBuilderTests {
     }
     
     func test_example_call() {
-        XCTAssertFalse(sut.request.requiresClientAttestations)
+        XCTAssertFalse(sut.request.requiresClientAttestation)
         XCTAssertFalse(sut.request.requiresDPoP)
         XCTAssertNil(sut.request.authScope)
         
@@ -78,7 +78,7 @@ extension RequestBuilderTests {
             .withDPoP()
         
         // Make sure request has all the set parameters
-        XCTAssertTrue(requestBuilder.request.requiresClientAttestations)
+        XCTAssertTrue(requestBuilder.request.requiresClientAttestation)
         XCTAssertTrue(requestBuilder.request.requiresDPoP)
         XCTAssertEqual(requestBuilder.request.authScope, "testAuth")
     }

--- a/Tests/NetworkingTests/RequestBuilderTests.swift
+++ b/Tests/NetworkingTests/RequestBuilderTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+@testable import Networking
+import XCTest
+
+
+final class RequestBuilderTests: XCTestCase {
+    // NetworkClient Mock
+    private final class MockNetworkClient: NetworkClientProtocol {
+        var receivedRequest: NetworkRequest?
+        
+        func makeRequest(_ request: NetworkRequest) async throws -> Data {
+            receivedRequest = request
+            return Data()
+        }
+    }
+    
+    private var sut: RequestBuilder!
+    private var mockNetworkClient: MockNetworkClient!
+    
+    override func setUp() {
+        super.setUp()
+        mockNetworkClient = MockNetworkClient()
+        sut = RequestBuilder(client: mockNetworkClient, request: URLRequest.example)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        mockNetworkClient = nil
+        super.tearDown()
+    }
+}
+
+extension RequestBuilderTests {    
+    func test_authentication_request() {
+        // No auth scope set by default
+        XCTAssertNil(sut.request.authScope)
+        
+        // Make sure request has an authscope
+        let newSut = sut.withAuthentication(scope: "test_auth_scope")
+        XCTAssertEqual(newSut.request.authScope, "test_auth_scope")
+    }
+    
+    func test_attestation_request() {
+        // No auth scope set by default
+        XCTAssertFalse(sut.request.requiresClientAttestations)
+        
+        // Make sure request has an authscope
+        let newSut = sut.withAttestation()
+        XCTAssertTrue(newSut.request.requiresClientAttestations)
+        XCTAssertFalse(newSut.request.requiresDPoP)
+    }
+    
+    func test_dPoP_request() {
+        // No auth scope set by default
+        XCTAssertFalse(sut.request.requiresDPoP)
+        
+        // Make sure request has an authscope
+        let newSut = sut.withDPoP()
+        XCTAssertTrue(newSut.request.requiresDPoP)
+        XCTAssertFalse(newSut.request.requiresClientAttestations)
+    }
+    
+    func test_execute_request() async throws {
+        let data = try await sut.execute()
+
+        XCTAssertEqual(data, Data())
+        // Make sure execute calls makeRequest on the NetworkClient its invoked
+        XCTAssertEqual(mockNetworkClient.receivedRequest?.urlRequest, URLRequest.example)
+    }
+    
+    func test_example_call() {
+        XCTAssertFalse(sut.request.requiresClientAttestations)
+        XCTAssertFalse(sut.request.requiresDPoP)
+        XCTAssertNil(sut.request.authScope)
+        
+        let requestBuilder = sut
+            .withAuthentication(scope: "testAuth")
+            .withAttestation()
+            .withDPoP()
+        
+        // Make sure request has all the set parameters
+        XCTAssertTrue(requestBuilder.request.requiresClientAttestations)
+        XCTAssertTrue(requestBuilder.request.requiresDPoP)
+        XCTAssertEqual(requestBuilder.request.authScope, "testAuth")
+    }
+}

--- a/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
+++ b/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
@@ -9,20 +9,13 @@ final class URLRequestTests: XCTestCase {
         XCTAssertEqual(authorizationHeader, "Bearer testBearerToken")
     }
     
-    func test_client_assertions() throws {
+    func test_header_insertion() throws {
         let assertionRequest = URLRequest.example
-            .clientAttestation(with: ["testClientAttestation": "12345",
-                                      "testPoP": "12345"])
+            .setHeaderValues(["testClientAttestation": "12345",
+                              "testPoP": "12345"])
         let assertionHeader = assertionRequest.value(forHTTPHeaderField: "testClientAttestation")
         XCTAssertEqual(assertionHeader, "12345")
         let assertionPoPHeader = assertionRequest.value(forHTTPHeaderField: "testPoP")
         XCTAssertEqual(assertionPoPHeader, "12345")
-    }
-    
-    func test_dPoP() throws {
-        let dPoPRequest = URLRequest.example
-            .dPoPAssertion(with: ["testDPoP": "12345"])
-        let dPoPHeader = dPoPRequest.value(forHTTPHeaderField: "testDPoP")
-        XCTAssertEqual(dPoPHeader, "12345")
     }
 }

--- a/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
+++ b/Tests/NetworkingTests/URLRequest+ExtensionsTests.swift
@@ -8,4 +8,21 @@ final class URLRequestTests: XCTestCase {
         let authorizationHeader = authorizedRequest.value(forHTTPHeaderField: "Authorization")
         XCTAssertEqual(authorizationHeader, "Bearer testBearerToken")
     }
+    
+    func test_client_assertions() throws {
+        let assertionRequest = URLRequest.example
+            .clientAttestation(with: ["testClientAttestation": "12345",
+                                      "testPoP": "12345"])
+        let assertionHeader = assertionRequest.value(forHTTPHeaderField: "testClientAttestation")
+        XCTAssertEqual(assertionHeader, "12345")
+        let assertionPoPHeader = assertionRequest.value(forHTTPHeaderField: "testPoP")
+        XCTAssertEqual(assertionPoPHeader, "12345")
+    }
+    
+    func test_dPoP() throws {
+        let dPoPRequest = URLRequest.example
+            .dPoPAssertion(with: ["testDPoP": "12345"])
+        let dPoPHeader = dPoPRequest.value(forHTTPHeaderField: "testDPoP")
+        XCTAssertEqual(dPoPHeader, "12345")
+    }
 }


### PR DESCRIPTION
# DCMAW-20186 New Request Builder pattern 

> Note: This is NOT a breaking change 

This pattern is introduced to provide an easy way of constructing authorisation, client attestation and drop network requests with any combination of these headers. 

## New way of making requests 
The following request will include the authentication, attestation and dPoP headers:
`NetworkClient().request(<your URLRequest>).withAuthentication(scope: "any scope").withAttestation().withDPoP().execute()
`
Remove the respective call for the headers you don't want included. These specifications (i.e withAttestation(), .withDPoP() etc) can be in any order when you construct the request.

> ### from now on .execute() is making the request rather than calling makeRequest() so you never have to call makeRequest() manually.

## NetworkClientProtocol

Make sure any **NetworkClient Wrapper extends the NetworkClientProtocol** from now on so that it has the request() function provided by the protocol. If you don't extend this protocol .execute() won't go through your wrapper and it will send the api request directly from the NetworkClient in this package. You should never have to implement the request() function manually.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
