### PR TITLE
fix: DCMAW-20415 add public init to NetworkRequest

### DIFF
--- a/Sources/Networking/NetworkRequest.swift
+++ b/Sources/Networking/NetworkRequest.swift
@@ -4,6 +4,18 @@ import Foundation
 public struct NetworkRequest {
     public var urlRequest: URLRequest
     public var authScope: String?
-    public var requiresClientAttestation: Bool = false
-    public var requiresDPoP: Bool = false
+    public var requiresClientAttestation: Bool
+    public var requiresDPoP: Bool
+    
+    public init(
+        urlRequest: URLRequest,
+        authScope: String? = nil,
+        requiresClientAttestation: Bool = false,
+        requiresDPoP: Bool = false
+    ) {
+        self.urlRequest = urlRequest
+        self.authScope = authScope
+        self.requiresClientAttestation = requiresClientAttestation
+        self.requiresDPoP = requiresDPoP
+    }
 }


### PR DESCRIPTION
# fix: DCMAW-20415 add public init to NetworkRequest

In order to construct a NetworkRequest object, the initialiser must be public.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
