### PR TITLE
fix: DCMAW-20858 expose response data in user info dict

### DIFF
--- a/Sources/Networking/ServerError.swift
+++ b/Sources/Networking/ServerError.swift
@@ -18,4 +18,12 @@ public struct ServerError: ErrorWithCode {
     }
 }
 
-extension ServerError: CustomNSError {}
+extension ServerError: CustomNSError {
+    public var errorUserInfo: [String: Any] {
+        var info: [String: Any] = [:]
+        if let response {
+            info["response"] = response
+        }
+        return info
+    }
+}

--- a/Tests/NetworkingTests/ServerErrorTests.swift
+++ b/Tests/NetworkingTests/ServerErrorTests.swift
@@ -21,4 +21,32 @@ struct ServerErrorTests {
         
         #expect(nsError.errorCode == 200)
     }
+
+    @Test("errorUserInfo includes response data when present")
+    func errorUserInfoIncludesResponse() throws {
+        // GIVEN: a ServerError with response data
+        let responseData = Data("""
+        {"error": "invalid_client"}
+        """.utf8)
+        let sut = ServerError(endpoint: "token", errorCode: 400, response: responseData)
+
+        // WHEN: accessing userInfo via NSError bridging
+        let nsError = sut as NSError
+
+        // THEN: the response data is accessible
+        let retrieved = try #require(nsError.userInfo["response"] as? Data)
+        #expect(retrieved == responseData)
+    }
+
+    @Test("errorUserInfo is empty when response is nil")
+    func errorUserInfoEmptyWhenNoResponse() {
+        // GIVEN: a ServerError without response data
+        let sut = ServerError(endpoint: "token", errorCode: 500)
+
+        // WHEN: accessing userInfo via NSError bridging
+        let nsError = sut as NSError
+
+        // THEN: userInfo has no response key
+        #expect(nsError.userInfo["response"] == nil)
+    }
 }


### PR DESCRIPTION
# DCMAW-20858 - expose response data in user info dictionary

So that consumers that do not directly depend on Networking, the response data needs to be exposed via a type that is available at a lower level (eg `CustomNSError`)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
